### PR TITLE
Add multisample anti-aliasing support for VR textures

### DIFF
--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -536,7 +536,8 @@ namespace dxvk {
           UINT                   Layer,
           UINT                   Lod,
           VkImageUsageFlags      UsageFlags,
-          bool                   Srgb) {    
+          bool                   Srgb,
+          bool                   Resolved) {
     DxvkImageViewCreateInfo viewInfo;
     viewInfo.format    = m_mapping.ConversionFormatInfo.FormatColor != VK_FORMAT_UNDEFINED
                        ? PickSRGB(m_mapping.ConversionFormatInfo.FormatColor, m_mapping.ConversionFormatInfo.FormatSrgb, Srgb)
@@ -565,7 +566,7 @@ namespace dxvk {
                            VK_COMPONENT_SWIZZLE_IDENTITY, VK_COMPONENT_SWIZZLE_IDENTITY };
 
     // Create the underlying image view object
-    return m_device->GetDXVKDevice()->createImageView(GetImage(), viewInfo);
+    return m_device->GetDXVKDevice()->createImageView(Resolved ? GetResolveImage() : GetImage(), viewInfo);
   }
 
 

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -1141,6 +1141,8 @@ namespace dxvk {
 
     uint64_t GetCurrentSequenceNumber();
 
+    void ResolveImage(D3D9CommonTexture* commonTex);
+
     Com<D3D9InterfaceEx>            m_parent;
     D3DDEVTYPE                      m_deviceType;
     HWND                            m_window;

--- a/src/d3d9/d3d9_vr.cpp
+++ b/src/d3d9/d3d9_vr.cpp
@@ -52,7 +52,7 @@ namespace dxvk {
             const auto *tex = surface->GetCommonTexture();
 
             const auto &desc = tex->Desc();
-            const auto &image = tex->GetImage();
+            const auto &image = desc->MultiSample != D3DMULTISAMPLE_NONE ? const_cast<D3D9CommonTexture*>(tex)->GetResolveImage() : tex->GetImage();
             const auto &device = tex->Device()->GetDXVKDevice();
 
             // I don't know why the image randomly is a uint64_t in OpenVR.

--- a/src/dxvk/dxvk_openvr.cpp
+++ b/src/dxvk/dxvk_openvr.cpp
@@ -263,7 +263,7 @@ namespace dxvk {
 
       // If the app has not initialized OpenVR yet, we need
       // to do it now in order to grab a compositor instance
-      g_vrFunctions.initInternal(&error, vr::VRApplication_Background);
+      g_vrFunctions.initInternal(&error, vr::VRApplication_Scene);
       m_initializedOpenVr = error == vr::VRInitError_None;
 
       if (error != vr::VRInitError_None) {
@@ -307,7 +307,7 @@ namespace dxvk {
   HMODULE VrInstance::loadLibrary() {
     HMODULE handle = nullptr;
     if (!(handle = ::GetModuleHandle("openvr_api.dll"))) {
-      handle = ::LoadLibrary("openvr_api_dxvk.dll");
+      handle = ::LoadLibrary("openvr_api.dll");
       m_loadedOvrApi = handle != nullptr;
     }
     return handle;


### PR DESCRIPTION
This is a backport from HL2VR to force the VR render textures to be multisampled if requested. I tested this with Gistix's Portal 2 VR fork, but I reckon it should work for L4D2 VR just as well, if you are interested.

Requires a small change in the l4d2vr repo, as well. See https://github.com/Gistix/portal2vr/pull/7 for reference